### PR TITLE
feat: coverage CLI + Web UI indicators for coverage and annotations

### DIFF
--- a/apps/cli/src/cli/commands.test.ts
+++ b/apps/cli/src/cli/commands.test.ts
@@ -22,6 +22,7 @@ describe("ringiCommand", () => {
     expect(names).toContain("todo");
     expect(names).toContain("serve");
     expect(names).toContain("mcp");
+    expect(names).toContain("coverage");
     expect(names).toContain("doctor");
     expect(names).toContain("events");
     expect(names).toContain("data");

--- a/apps/cli/src/cli/commands.ts
+++ b/apps/cli/src/cli/commands.ts
@@ -17,6 +17,7 @@ import { resolve } from "node:path";
 import { CoreLive } from "@ringi/core/runtime";
 import type { ReviewId } from "@ringi/core/schemas/review";
 import { CommentService } from "@ringi/core/services/comment.service";
+import { CoverageService } from "@ringi/core/services/coverage.service";
 import { getDiffSummary, parseDiff } from "@ringi/core/services/diff.service";
 import { ExportService } from "@ringi/core/services/export.service";
 import { GitService } from "@ringi/core/services/git.service";
@@ -1380,6 +1381,83 @@ const mcp = Command.make(
 ).pipe(Command.withDescription("Start the MCP stdio server"));
 
 // ---------------------------------------------------------------------------
+// coverage
+// ---------------------------------------------------------------------------
+
+const coverageCmd = Command.make(
+  "coverage",
+  {
+    id: Argument.string("id"),
+    files: Flag.boolean("files").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Show per-file breakdown")
+    ),
+  },
+  (config) =>
+    Effect.gen(function* () {
+      yield* ensureDatabaseExists;
+      const coverageService = yield* CoverageService;
+      const reviewService = yield* ReviewService;
+      const reviewId = yield* resolveReviewSelector(config.id);
+
+      // Validate review exists
+      const review = yield* reviewService.getById(reviewId);
+      const summary = yield* coverageService.getSummary(reviewId);
+
+      const pct = (n: number) =>
+        summary.totalHunks > 0
+          ? `${Math.round((n / summary.totalHunks) * 100)}%`
+          : "0%";
+
+      const data: Record<string, unknown> = {
+        reviewId: review.id,
+        summary,
+      };
+
+      const lines = [
+        `Review ${review.id} coverage:`,
+        `  Total hunks:      ${String(summary.totalHunks).padStart(4)}`,
+        `  Reviewed:         ${String(summary.reviewedHunks).padStart(4)}  (${pct(summary.reviewedHunks)})`,
+        `  Partial:          ${String(summary.partialHunks).padStart(4)}  (${pct(summary.partialHunks)})`,
+        `  Unreviewed:       ${String(summary.unreviewedHunks).padStart(4)}  (${pct(summary.unreviewedHunks)})`,
+      ];
+
+      if (config.files) {
+        // Get per-file hunk counts from the review
+        // We reuse the review files data from getById
+        lines.push("");
+        for (const file of review.files) {
+          const fileHunks = yield* reviewService.getFileHunks(
+            reviewId,
+            file.filePath
+          );
+          const totalFileHunks = fileHunks.length;
+          // Simple dots visualization
+          const dots = fileHunks.map(() => "○").join("");
+          lines.push(
+            `${file.filePath.padEnd(40)} ${totalFileHunks} hunks  ${dots}`
+          );
+        }
+      }
+
+      yield* emitOutput("ringi coverage", {
+        data,
+        human: lines.join("\n"),
+        nextActions: [
+          {
+            command: `ringi review show ${reviewId}`,
+            description: "View review details",
+          },
+          {
+            command: `ringi coverage ${reviewId} --files`,
+            description: "Show per-file coverage breakdown",
+          },
+        ],
+      });
+    })
+).pipe(Command.withDescription("Show review coverage summary"));
+
+// ---------------------------------------------------------------------------
 // doctor
 // ---------------------------------------------------------------------------
 
@@ -1446,6 +1524,7 @@ const data = Command.make("data").pipe(
 const reviewWithCore = provideCoreLayer(review) as any;
 const sourceWithGit = provideGitLayer(source) as any;
 const todoWithCore = provideCoreLayer(todo) as any;
+const coverageWithCore = provideCoreLayer(coverageCmd) as any;
 const doctorWithCore = provideCoreLayer(doctor) as any;
 
 export const ringiCommand = Command.make("ringi").pipe(
@@ -1460,6 +1539,7 @@ export const ringiCommand = Command.make("ringi").pipe(
     reviewWithCore,
     sourceWithGit,
     todoWithCore,
+    coverageWithCore,
     serve,
     mcp,
     doctorWithCore,

--- a/apps/web/src/routes/-shared/layout/action-bar.tsx
+++ b/apps/web/src/routes/-shared/layout/action-bar.tsx
@@ -57,6 +57,9 @@ interface ActionBarProps {
   // ── Utilities ────────────────────────────────────────────────────
   onExport?: () => void;
   onCopyDiff?: () => void;
+
+  /** e.g. "12/18 hunks reviewed" */
+  coverageLabel?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -295,6 +298,7 @@ export const ActionBar = ({
   onToggleAnnotations,
   onExport,
   onCopyDiff,
+  coverageLabel,
 }: ActionBarProps) => {
   // ── Copy feedback ───────────────────────────────────────────
   const [copyFeedback, setCopyFeedback] = useState(false);
@@ -413,6 +417,13 @@ export const ActionBar = ({
 
       {/* ── Right: review state / progress / action ──────────── */}
       <div className="flex shrink-0 items-center gap-1.5 pr-2.5">
+        {/* Coverage summary */}
+        {coverageLabel ? (
+          <span className="text-[11px] tabular-nums text-text-tertiary">
+            {coverageLabel}
+          </span>
+        ) : null}
+
         {/* Review progress: "4/13 reviewed" */}
         {hasProgress ? (
           <span

--- a/apps/web/src/routes/-shared/layout/action-bar.tsx
+++ b/apps/web/src/routes/-shared/layout/action-bar.tsx
@@ -60,6 +60,9 @@ interface ActionBarProps {
 
   /** e.g. "12/18 hunks reviewed" */
   coverageLabel?: string;
+
+  /** e.g. "12 annotations (3 sources)" */
+  annotationLabel?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +302,7 @@ export const ActionBar = ({
   onExport,
   onCopyDiff,
   coverageLabel,
+  annotationLabel,
 }: ActionBarProps) => {
   // ── Copy feedback ───────────────────────────────────────────
   const [copyFeedback, setCopyFeedback] = useState(false);
@@ -421,6 +425,13 @@ export const ActionBar = ({
         {coverageLabel ? (
           <span className="text-[11px] tabular-nums text-text-tertiary">
             {coverageLabel}
+          </span>
+        ) : null}
+
+        {/* External annotation count */}
+        {annotationLabel ? (
+          <span className="text-[11px] tabular-nums text-status-info/70">
+            {annotationLabel}
           </span>
         ) : null}
 

--- a/apps/web/src/routes/reviews/$reviewId.tsx
+++ b/apps/web/src/routes/reviews/$reviewId.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@ringi/core/schemas/diff";
 import { ReviewId } from "@ringi/core/schemas/review";
 import type { ReviewStatus } from "@ringi/core/schemas/review";
+import { AnnotationService } from "@ringi/core/services/annotation.service";
 import { CommentService } from "@ringi/core/services/comment.service";
 import { CoverageService } from "@ringi/core/services/coverage.service";
 import { ReviewService } from "@ringi/core/services/review.service";
@@ -55,6 +56,7 @@ interface ReviewDetailData {
   comments: readonly Comment[];
   commentStats: { total: number; resolved: number; unresolved: number };
   coverage: CoverageSummary;
+  annotationStats: { total: number; bySource: Record<string, number> };
 }
 
 const loadReview = createServerFn({ method: "GET" })
@@ -72,13 +74,15 @@ const loadReview = createServerFn({ method: "GET" })
         const reviewSvc = yield* ReviewService;
         const commentSvc = yield* CommentService;
         const coverageSvc = yield* CoverageService;
+        const annotationSvc = yield* AnnotationService;
 
         const review = yield* reviewSvc.getById(id);
         const comments = yield* commentSvc.getByReview(id);
         const commentStats = yield* commentSvc.getStats(id);
         const coverage = yield* coverageSvc.getSummary(id);
+        const annotationStats = yield* annotationSvc.stats(id);
 
-        return { ...review, commentStats, comments, coverage };
+        return { ...review, annotationStats, commentStats, comments, coverage };
       })
     );
     return JSON.parse(JSON.stringify(result));
@@ -290,6 +294,12 @@ const ReviewDetailPage = () => {
       ? `${data.coverage.reviewedHunks}/${data.coverage.totalHunks} hunks reviewed`
       : undefined;
 
+  const annotationSources = Object.keys(data.annotationStats.bySource);
+  const annotationLabel =
+    data.annotationStats.total > 0
+      ? `${data.annotationStats.total} annotations${annotationSources.length > 0 ? ` (${annotationSources.length} source${annotationSources.length > 1 ? "s" : ""})` : ""}`
+      : undefined;
+
   return (
     <div className="flex h-full flex-col">
       <ActionBar
@@ -311,6 +321,7 @@ const ReviewDetailPage = () => {
         onToggleAnnotations={toggleAnnotations}
         onExport={handleExport}
         coverageLabel={coverageLabel}
+        annotationLabel={annotationLabel}
       />
 
       <div className="flex min-h-0 flex-1">

--- a/apps/web/src/routes/reviews/$reviewId.tsx
+++ b/apps/web/src/routes/reviews/$reviewId.tsx
@@ -1,4 +1,5 @@
 import type { Comment } from "@ringi/core/schemas/comment";
+import type { CoverageSummary } from "@ringi/core/schemas/coverage";
 import type {
   DiffFile as DiffFileType,
   DiffSummary as DiffSummaryType,
@@ -6,6 +7,7 @@ import type {
 import { ReviewId } from "@ringi/core/schemas/review";
 import type { ReviewStatus } from "@ringi/core/schemas/review";
 import { CommentService } from "@ringi/core/services/comment.service";
+import { CoverageService } from "@ringi/core/services/coverage.service";
 import { ReviewService } from "@ringi/core/services/review.service";
 import { createFileRoute } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
@@ -52,6 +54,7 @@ interface ReviewDetailData {
   repository: string | null;
   comments: readonly Comment[];
   commentStats: { total: number; resolved: number; unresolved: number };
+  coverage: CoverageSummary;
 }
 
 const loadReview = createServerFn({ method: "GET" })
@@ -68,12 +71,14 @@ const loadReview = createServerFn({ method: "GET" })
       Effect.gen(function* result() {
         const reviewSvc = yield* ReviewService;
         const commentSvc = yield* CommentService;
+        const coverageSvc = yield* CoverageService;
 
         const review = yield* reviewSvc.getById(id);
         const comments = yield* commentSvc.getByReview(id);
         const commentStats = yield* commentSvc.getStats(id);
+        const coverage = yield* coverageSvc.getSummary(id);
 
-        return { ...review, commentStats, comments };
+        return { ...review, commentStats, comments, coverage };
       })
     );
     return JSON.parse(JSON.stringify(result));
@@ -280,6 +285,11 @@ const ReviewDetailPage = () => {
   const diffSummary: DiffSummaryType = data.summary;
   const repoName = data.repositoryPath.split("/").pop() ?? data.repositoryPath;
 
+  const coverageLabel =
+    data.coverage.totalHunks > 0
+      ? `${data.coverage.reviewedHunks}/${data.coverage.totalHunks} hunks reviewed`
+      : undefined;
+
   return (
     <div className="flex h-full flex-col">
       <ActionBar
@@ -300,6 +310,7 @@ const ReviewDetailPage = () => {
         isAnnotationsOpen={state.annotationsOpen}
         onToggleAnnotations={toggleAnnotations}
         onExport={handleExport}
+        coverageLabel={coverageLabel}
       />
 
       <div className="flex min-h-0 flex-1">


### PR DESCRIPTION
## Summary

Implements surface integration for coverage and annotations across CLI and Web UI, building on the foundation from #15.

### CLI: `ringi coverage` command (#8)
- `ringi coverage <reviewId>` — summary table with total/reviewed/partial/unreviewed + percentages
- `ringi coverage <reviewId> --files` — per-file hunk count breakdown
- `ringi coverage <reviewId> --json` — structured JSON envelope for agent consumption
- Works in standalone mode (direct SQLite read, no server required)
- Supports `--repo` and `--db-path` global flags

### Web UI: Coverage indicators (#9)
- Coverage summary loaded via `CoverageService` in review detail server function
- Displayed in ActionBar header: `"12/18 hunks reviewed"`
- Shows only when `totalHunks > 0`

### Web UI: Annotation count badges (#13)
- Annotation stats (total + bySource breakdown) loaded via `AnnotationService`
- Displayed in ActionBar: `"12 annotations (3 sources)"`
- Uses distinct info color, separate from comment count
- Shows only when annotations exist

## Quality Gates
- ✅ **typecheck**: all 3 workspaces pass
- ✅ **lint+format**: 0 errors
- ✅ **tests**: 225 passed (0 failures)

## Closes
Closes #8, closes #9, closes #13
